### PR TITLE
Changing background color to "#3c3c3c" for Start mod

### DIFF
--- a/VertUI.FCParam
+++ b/VertUI.FCParam
@@ -116,6 +116,11 @@
           <FCUInt Name="ItemBackground" Value="0"/>
           <FCUInt Name="TreeActiveColor" Value="252645887"/>
         </FCParamGroup>
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Start">
+            <FCUInt Name="BackgroundColor1" Value="1010580735"/>
+          </FCParamGroup>
+        </FCParamGroup>
       </FCParamGroup>
       <FCParamGroup Name="MainWindow">
         <FCParamGroup Name="StatusBar">


### PR DESCRIPTION
Changed background color to "#3c3c3c" for Start mod

Before:
![изображение](https://user-images.githubusercontent.com/6413014/151601242-2f13b86e-1675-4eee-8856-7bea53b5c541.png)
After:
![изображение](https://user-images.githubusercontent.com/6413014/151601379-a676903f-d6fd-46c5-ad8d-f43ed21a2cbe.png)
